### PR TITLE
Feature - edit todo list name

### DIFF
--- a/src/main/java/fr/LaurentFE/todolistclient/MainWindow.java
+++ b/src/main/java/fr/LaurentFE/todolistclient/MainWindow.java
@@ -54,7 +54,7 @@ public class MainWindow extends JFrame {
         contentPane.repaint();
     }
 
-    private void refreshListContentPane() {
+    public void refreshListContentPane() {
         listSplitPane.setLeftComponent(createListPane());
         listSplitPane.getLeftComponent().revalidate();
         listSplitPane.getLeftComponent().repaint();
@@ -334,7 +334,7 @@ public class MainWindow extends JFrame {
     }
 
     private void openList(ToDoList list) {
-        ToDoListWindow todo = new ToDoListWindow(list, currentUser);
+        ToDoListWindow todo = new ToDoListWindow(this, list, currentUser);
         todo.setVisible(true);
         desktopPane.add(todo);
         todo.moveToFront();

--- a/src/main/java/fr/LaurentFE/todolistclient/ToDoListWindow.java
+++ b/src/main/java/fr/LaurentFE/todolistclient/ToDoListWindow.java
@@ -17,9 +17,11 @@ public class ToDoListWindow extends JInternalFrame {
     static final int baseHeight = 70;
     static final int heightIncrement = 50;
     private final String userName;
+    private final MainWindow mainWindowRef;
 
-    public ToDoListWindow(ToDoList list, String userName) {
+    public ToDoListWindow(MainWindow mainWindowRef, ToDoList list, String userName) {
         super(list.getLabel(), true, true, false, false);
+        this.mainWindowRef = mainWindowRef;
         openFrameCount++;
         toDoList = list;
         this.userName = userName;
@@ -41,6 +43,8 @@ public class ToDoListWindow extends JInternalFrame {
         JPanel contentPane = (JPanel) this.getContentPane();
         contentPane.removeAll();
 
+        this.setTitle(toDoList.getLabel());
+
         contentPane.setLayout(new BorderLayout());
 
         if (toDoList.getItems() != null) {
@@ -59,8 +63,7 @@ public class ToDoListWindow extends JInternalFrame {
         JToolBar toolBar = new JToolBar();
         toolBar.setFloatable(false);
 
-        JButton editListName = new JButton(new ImageIcon("src/main/resources/edit-list.png"));
-        toolBar.add(editListName);
+        toolBar.add(actEditListName);
         toolBar.add(actAddItem);
 
         return toolBar;
@@ -144,4 +147,34 @@ public class ToDoListWindow extends JInternalFrame {
             }
         }
     };
+
+    private final AbstractAction actEditListName = new AbstractAction() {
+        {
+            putValue(Action.NAME, "Edit List");
+            putValue(Action.SHORT_DESCRIPTION, "Edit List");
+            putValue(Action.SMALL_ICON, new ImageIcon("src/main/resources/edit-list.png"));
+        }
+        @Override
+        public void actionPerformed(ActionEvent evt) {
+            String newListName = JOptionPane.showInputDialog(
+                    null,
+                    "Enter new list name",
+                    "Edit list name",
+                    JOptionPane.QUESTION_MESSAGE);
+            if (newListName != null) {
+                String escapedUserName = ServerManager.escapeLabelForAPI(userName);
+                String escapedListName = ServerManager.escapeLabelForAPI(toDoList.getLabel());
+                String escapedNewListName = ServerManager.escapeLabelForAPI(newListName);
+                String endpoint = ServerManager.getInstance()
+                        .getServerConfig().getServer_url() + "/rest/ToDoListName?user_name=" + escapedUserName
+                        + "&list_name=" + escapedListName
+                        + "&new_list_name=" + escapedNewListName;
+                ServerManager.sendPutRequest(endpoint);
+                toDoList.setLabel(newListName);
+                refreshToDoList();
+                refreshContentPane();
+                mainWindowRef.refreshListContentPane();
+            }
+        }
+    } ;
 }

--- a/src/main/java/fr/LaurentFE/todolistclient/config/ServerManager.java
+++ b/src/main/java/fr/LaurentFE/todolistclient/config/ServerManager.java
@@ -87,4 +87,16 @@ public class ServerManager {
             throw new RuntimeException(e);
         }
     }
+
+    public static void sendPutRequest(String endpoint) {
+        try (HttpClient httpClient = HttpClient.newHttpClient()) {
+            HttpRequest postRequest = HttpRequest.newBuilder()
+                    .uri(new URI(endpoint))
+                    .PUT(HttpRequest.BodyPublishers.ofString(""))
+                    .build();
+            httpClient.send(postRequest, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException | InterruptedException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }


### PR DESCRIPTION
User can edit the name of an opened todo list with the dedicated button. This changed the name of the current list window, and updates the name in the buttons of the list section. 

Added PUT request handling in ServerManager.