### PR TITLE
Feature - edit list item name

### DIFF
--- a/src/main/java/fr/LaurentFE/todolistclient/ListItem.java
+++ b/src/main/java/fr/LaurentFE/todolistclient/ListItem.java
@@ -2,7 +2,7 @@ package fr.LaurentFE.todolistclient;
 
 public class ListItem {
     private final Integer item_id;
-    private final String label;
+    private String label;
     private final Boolean checked;
 
     public ListItem(Integer item_id, String label, Boolean checked) {
@@ -13,6 +13,10 @@ public class ListItem {
 
     public String getLabel() {
         return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
     }
 
     public Boolean isChecked() {

--- a/src/main/java/fr/LaurentFE/todolistclient/ToDoListWindow.java
+++ b/src/main/java/fr/LaurentFE/todolistclient/ToDoListWindow.java
@@ -95,7 +95,8 @@ public class ToDoListWindow extends JInternalFrame {
         JLabel label = new JLabel(item.getLabel());
 
         JPanel editPanel = new JPanel();
-        JButton editItem = new JButton(new ImageIcon("src/main/resources/edit-item.png"));
+        JButton editItem = new JButton(actEditItemName);
+        editItem.setName(item.getLabel());
 
         listPanel.add(checkBox);
         listPanel.add(label);
@@ -145,7 +146,6 @@ public class ToDoListWindow extends JInternalFrame {
 
     private final AbstractAction actAddItem = new AbstractAction() {
         {
-            putValue(Action.NAME, "Add Item");
             putValue(Action.SHORT_DESCRIPTION, "Add Item");
             putValue(Action.SMALL_ICON, new ImageIcon("src/main/resources/add-item.png"));
         }
@@ -194,6 +194,48 @@ public class ToDoListWindow extends JInternalFrame {
                         + "&new_list_name=" + escapedNewListName;
                 ServerManager.sendPutRequest(endpoint);
                 toDoList.setLabel(newListName);
+                refreshToDoList();
+                refreshContentPane();
+                mainWindowRef.refreshListContentPane();
+            }
+        }
+    };
+
+    private final AbstractAction actEditItemName = new AbstractAction() {
+        {
+            putValue(Action.NAME, "Edit Item Name");
+            putValue(Action.SHORT_DESCRIPTION, "Edit Item Name");
+            putValue(Action.SMALL_ICON, new ImageIcon("src/main/resources/edit-item.png"));
+        }
+        @Override
+        public void actionPerformed(ActionEvent evt) {
+            JButton button = (JButton) evt.getSource();
+            String itemName = button.getName();
+            String newItemName = JOptionPane.showInputDialog(
+                    null,
+                    "Enter new item name",
+                    "Edit item name",
+                    JOptionPane.QUESTION_MESSAGE,
+                    null,
+                    null,
+                    itemName).toString();
+            if (newItemName != null) {
+                String escapedUserName = ServerManager.escapeLabelForAPI(userName);
+                String escapedListName = ServerManager.escapeLabelForAPI(toDoList.getLabel());
+                String escapedItemName = ServerManager.escapeLabelForAPI(itemName);
+                String escapedNewItemName = ServerManager.escapeLabelForAPI(newItemName);
+                String endpoint = ServerManager.getInstance()
+                        .getServerConfig().getServer_url() + "/rest/ListItemName?user_name=" + escapedUserName
+                        + "&list_name=" + escapedListName
+                        + "&item_name=" + escapedItemName
+                        + "&new_item_name=" + escapedNewItemName;
+                ServerManager.sendPutRequest(endpoint);
+                for (ListItem item : toDoList.getItems()) {
+                    if (item.getLabel().equals(itemName)) {
+                        item.setLabel(newItemName);
+                        break;
+                    }
+                }
                 refreshToDoList();
                 refreshContentPane();
                 mainWindowRef.refreshListContentPane();


### PR DESCRIPTION
User can click on the edit button on the right side of an item in a todo list, and they will be prompted with a prefilled field they can use to modify the list item label.

Change is saved in DB (API PUT call), data in the client is refreshed and so is the display.